### PR TITLE
Fix spelling / capitalisation of CloudBees 

### DIFF
--- a/src/main/resources/org/jenkins/plugins/cloudbees/Messages.properties
+++ b/src/main/resources/org/jenkins/plugins/cloudbees/Messages.properties
@@ -1,7 +1,7 @@
-CloudbeesPublisher.noArtifacts = skip cloudbees deployment as no artifacts has been saved for project {0}
+CloudbeesPublisher.noArtifacts = skip CloudBees deployment as no artifacts has been saved for project {0}
 CloudbeesPublisher.noWarArtifacts = no war artifacts has been saved are you sure your build produced some ?
 CloudbeesPublisher.perform = CloudbeesPublisher :: perform {0} :: {1}
-CloudbeesPublisher.displayName = Cloudbess Deployment
+CloudbeesPublisher.displayName = CloudBees Deployment
 CloudbeesPublisher.nameNotEmpty = Name cannot be empty
 CloudbeesPublisher.apiKeyNotEmpty = API Key cannot be empty
 CloudbeesPublisher.secretKeyNotEmpty = Secret Key cannot be empty


### PR DESCRIPTION
Just a quick fix for a typo in the plugin labels.

Thanks,

Ben
